### PR TITLE
fix: data(jobs.ts) -> general instructions file typo

### DIFF
--- a/data/jobs.ts
+++ b/data/jobs.ts
@@ -14,7 +14,7 @@ export const jobsData: Jobs[] = [
     'category': 'staff',
     'details': '',
     'lastDate': '27.01.2025',
-    'generalInstructions': '/docs/Advertisement_for_the_recruitment_of_research_fellows.pdf',
+    'generalInstructions': '/docs/Advertisment_for_the_recruitment_of_research_fellows.pdf',
     'application': 'https://forms.gle/hbMbhnYxnRWYo7C79',
     'extraInfo': []
   },


### PR DESCRIPTION
The provided .pdf file has a typo in the spelling of Advertisement, missing an e after s.